### PR TITLE
Add flag to suppress dolfin-adjoint

### DIFF
--- a/pulse/__init__.py
+++ b/pulse/__init__.py
@@ -1,6 +1,23 @@
 import logging as _logging
+import os
+
+# Check if dolfin-adjoint is installed, and if
+# the 'DOLFIN_ADJOINT' flag is set to 0, then
+# we remove it from sys.modules
+try:
+    import dolfin_adjoint  # noqa: F401
+except ImportError:
+    pass
+else:
+    if not bool(int(os.getenv("DOLFIN_ADJOINT", "1"))):
+        import sys
+
+        sys.modules["dolfin_adjoint"] = None  # type: ignore
+        _logging.warning("Dolfin-adjoint found but will be turned off")
+
 
 import daiquiri as _daiquiri
+
 
 from . import dolfin_utils
 from . import geometry


### PR DESCRIPTION
If you set the environement variable `DOLFIN_ADJOINT` to 0 then it will remove `dolfin_adjoint` from `sys.modules` even if it is installed. The main reason for this is that we primarily support `pyadjoint` while there are a lot of code that still uses `libadjoint`