### PR TITLE
Use correct parameter in benchmark problems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,23 +6,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        container:
-          [
-            "ghcr.io/scientificcomputing/fenics-gmsh:2023-08-16",
-            "finsberg/pyadjoint-extra",
-          ]
 
     container:
-      image: ${{ matrix.container }}
+      image: "ghcr.io/scientificcomputing/fenics-gmsh:2024-02-19"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache
         id: cache-primes
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/instant
@@ -40,9 +33,10 @@ jobs:
 
 
       - name: Test with pytest
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 120
-          max_attempts: 5
-          retry_on: error
-          command: python3 -m pytest
+        run: python3 -m pytest
+
+      - name: Install dolfin-adjoint
+        run:  python3 -m pip install dolfin-adjoint
+
+      - name: Test with pyadjoint
+        run: python3 -m pytest

--- a/demo/benchmark/problem2.py
+++ b/demo/benchmark/problem2.py
@@ -17,14 +17,20 @@ except ImportError:
     from dolfin import DirichletBC, Constant, interpolate, Mesh
 
 import pulse
+import cardiac_geometries as cg
 from fenics_plotly import plot
 
-here = Path(__file__).absolute().parent
 
-
-geometry = pulse.HeartGeometry.from_file(pulse.mesh_paths["benchmark"])
-# geometry = pulse.geometries.benchmark_ellipsoid_geometry()
-
+geo_path = Path("geometry")
+if not geo_path.is_dir():
+    cg.create_benchmark_geometry_land15(outdir=geo_path)
+geo = cg.geometry.Geometry.from_folder(geo_path)
+geometry = pulse.HeartGeometry(
+    mesh=geo.mesh,
+    markers=geo.markers,
+    marker_functions=pulse.MarkerFunctions(vfun=geo.vfun, ffun=geo.ffun),
+    microstructure=pulse.Microstructure(f0=geo.f0, s0=geo.s0, n0=geo.n0),
+)
 
 # Create the material
 material_parameters = pulse.Guccione.default_parameters()

--- a/demo/benchmark/problem2.py
+++ b/demo/benchmark/problem2.py
@@ -69,7 +69,7 @@ pulse.iterate.iterate(problem, lvp, 10.0, initial_number_of_steps=200)
 # Get displacement and hydrostatic pressure
 u, p = problem.state.split(deepcopy=True)
 
-endo_apex_marker = geometry.markers["APEX_ENDO"][0]
+endo_apex_marker = geometry.markers["ENDOPT"][0]
 endo_apex_idx = geometry.vfun.array().tolist().index(endo_apex_marker)
 endo_apex = geometry.mesh.coordinates()[endo_apex_idx, :]
 endo_apex_pos = endo_apex + u(endo_apex)
@@ -81,7 +81,7 @@ print(
 )
 
 
-epi_apex_marker = geometry.markers["APEX_EPI"][0]
+epi_apex_marker = geometry.markers["EPIPT"][0]
 epi_apex_idx = geometry.vfun.array().tolist().index(epi_apex_marker)
 epi_apex = geometry.mesh.coordinates()[epi_apex_idx, :]
 epi_apex_pos = epi_apex + u(epi_apex)

--- a/demo/benchmark/problem2.py
+++ b/demo/benchmark/problem2.py
@@ -28,7 +28,7 @@ geometry = pulse.HeartGeometry.from_file(pulse.mesh_paths["benchmark"])
 
 # Create the material
 material_parameters = pulse.Guccione.default_parameters()
-material_parameters["CC"] = 10.0
+material_parameters["C"] = 10.0
 material_parameters["bf"] = 1.0
 material_parameters["bfs"] = 1.0
 material_parameters["bt"] = 1.0

--- a/demo/benchmark/problem3.py
+++ b/demo/benchmark/problem3.py
@@ -22,7 +22,7 @@ geometry = pulse.HeartGeometry.from_file(pulse.mesh_paths["benchmark"])
 
 # Create the material
 material_parameters = pulse.Guccione.default_parameters()
-material_parameters["CC"] = 2.0
+material_parameters["C"] = 2.0
 material_parameters["bf"] = 8.0
 material_parameters["bfs"] = 4.0
 material_parameters["bt"] = 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test = [
     "fenics-plotly",
     "pytest-cov",
     "pytest-env",
+    "cardiac-geometries>=1.1.2"
 ]
 all = [
    "fenics-pulse[test]",


### PR DESCRIPTION
Fixes https://github.com/finsberg/pulse/issues/97

Output from problem 2 is now
```
Get longitudinal position of endocardial apex: 26.5328 mm
Get longitudinal position of epicardial apex: 28.1790 mm
```
and problem 3 is 
```
Get longitudinal position of endocardial apex: -11.9958 mm
Get longitudinal position of epicardial apex: -15.2232 mm
```

Main bug was
1. Passed the wrong parameter (i.e `CC` instead of `C`) in the material model.
2. Something wrong with the mesh or fibers stored in pulse.


We will now create the mesh automatically using [`cardiac-geometries`](https://github.com/ComputationalPhysiology/cardiac_geometries)