### PR TITLE
Add destructor to clean up SNES solver resources

### DIFF
--- a/src/pulse/solver.py
+++ b/src/pulse/solver.py
@@ -167,8 +167,8 @@ class NonlinearSolver:
             logger.debug(f"Resiudal      : {residuals[-1]}")
 
         return num_iterations, self._snes.converged
-    
+
     def __del__(self):
-        # Clean up the solver resources 
+        # Clean up the solver resources
         # to avoid memory leaks
         self._snes.destroy()

--- a/src/pulse/solver.py
+++ b/src/pulse/solver.py
@@ -167,3 +167,8 @@ class NonlinearSolver:
             logger.debug(f"Resiudal      : {residuals[-1]}")
 
         return num_iterations, self._snes.converged
+    
+    def __del__(self):
+        # Clean up the solver resources 
+        # to avoid memory leaks
+        self._snes.destroy()


### PR DESCRIPTION
Ensure that the SNES solver is properly destroyed when the object is deleted, in the solver.

Fixes #
preventing memory leaks by calling self._snes.destroy() in the destructor.
